### PR TITLE
Ten composable design upgrades

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -525,6 +525,15 @@ video {
   text-decoration-color: var(--color-accent);
 }
 
+/* Mark links that leave the site with a small north-east arrow. */
+.prose a[href^="http"]:not([href*="kirillbobyrev.com"])::after {
+  content: "\2197";
+  font-size: 0.7em;
+  margin-inline-start: 0.1em;
+  vertical-align: 0.2em;
+  color: var(--color-muted);
+}
+
 .main-content h1 {
   font-family: var(--font-serif);
   font-size: var(--step-3);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -633,6 +633,23 @@ video {
   scroll-margin-block-start: 2rem;
 }
 
+/* Flash the element a fragment link points at (headings, footnotes) so the
+   eye lands on it after the jump. */
+.main-content :target {
+  animation: target-highlight 2s ease-out;
+  border-radius: var(--radius-sm);
+}
+
+@keyframes target-highlight {
+  0%,
+  30% {
+    background-color: color-mix(in srgb, var(--color-sky) 22%, transparent);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
 a.heading-anchor {
   font-family: var(--font-sans);
   font-size: 0.8em;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -797,6 +797,26 @@ a.heading-anchor:hover {
   padding: 0;
 }
 
+/* Year groups on the blog listing: quiet overline label, shorter dates. */
+.main-content .timeline-year-label {
+  /* Outranks the .main-content h2 heading style on purpose: the year is a
+     quiet overline label, not a section heading. */
+  margin: 1.75rem 0 0.25rem;
+  font-family: var(--font-sans);
+  font-size: var(--step--1);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+}
+
+.timeline-year .blog-timeline {
+  margin-block-start: 0;
+}
+
+.timeline-year .blog-timeline-date {
+  width: 3.25rem;
+}
+
 .blog-timeline li {
   margin: 0;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -615,6 +615,44 @@ video {
   margin-block: 2.25rem;
 }
 
+/* === Post navigation (older / newer) === */
+.post-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-block-start: 2.75rem;
+  padding-block-start: 1.25rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.post-nav-link {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  max-width: 48%;
+  text-decoration: none;
+}
+
+.post-nav-newer {
+  margin-inline-start: auto;
+  text-align: right;
+}
+
+.post-nav-label {
+  font-size: var(--step--1);
+  color: var(--color-muted);
+}
+
+.post-nav-title {
+  font-weight: 500;
+  color: var(--color-heading);
+  transition: color var(--transition);
+}
+
+.post-nav-link:hover .post-nav-title {
+  color: var(--color-accent);
+}
+
 /* === Tables === */
 .table-wrapper {
   margin-block: 1.5rem;
@@ -991,6 +1029,17 @@ code:not(pre code) {
   .blog-timeline-date {
     text-align: left;
     width: auto;
+  }
+
+  .post-nav {
+    flex-direction: column;
+  }
+
+  .post-nav-link,
+  .post-nav-newer {
+    max-width: none;
+    margin-inline-start: 0;
+    text-align: left;
   }
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -797,6 +797,18 @@ a.heading-anchor:hover {
   font-style: italic;
 }
 
+/* Soften bright images against the dark background (filter values cannot
+   ride light-dark(), so this one rule keeps the dual theme scope). */
+:root[data-theme="dark"] .prose img {
+  filter: brightness(0.85) contrast(1.05);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .prose img {
+    filter: brightness(0.85) contrast(1.05);
+  }
+}
+
 /* === Code === */
 .highlight {
   border-radius: var(--radius);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -537,6 +537,7 @@ video {
   margin: 2.25rem 0 0.75rem;
   color: var(--color-heading);
   letter-spacing: -0.005em;
+  text-wrap: balance;
 }
 
 .main-content h3 {
@@ -546,10 +547,17 @@ video {
   line-height: 1.3;
   margin: 1.75rem 0 0.6rem;
   color: var(--color-heading);
+  text-wrap: balance;
 }
 
 .prose p {
   margin-block: 0.9em;
+}
+
+/* Nicer paragraph rag: avoids single-word last lines (orphans). */
+.prose p,
+.prose li {
+  text-wrap: pretty;
 }
 
 .prose ul {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -182,6 +182,18 @@ body {
   margin: 0;
 }
 
+/* Cross-fade between pages where the browser supports cross-document
+   view transitions; everyone else gets an instant navigation. */
+@view-transition {
+  navigation: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @view-transition {
+    navigation: none;
+  }
+}
+
 img,
 svg,
 video {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -144,6 +144,13 @@ html {
   scroll-behavior: smooth;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  /* Scrollbars pick up the theme instead of the UA default. */
+  scrollbar-color: var(--color-underline) transparent;
+}
+
+.highlight pre,
+.table-wrapper {
+  scrollbar-width: thin;
 }
 
 /* Large monitors: scale the root up (and widen the column) so the page fills

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -943,6 +943,45 @@ code:not(pre code) {
   }
 }
 
+/* === Print === */
+@media print {
+  :root,
+  :root[data-theme="dark"] {
+    color-scheme: light;
+  }
+
+  .site-header,
+  .site-footer,
+  .back-link,
+  .toc,
+  .post-nav {
+    display: none;
+  }
+
+  .site-container {
+    max-width: none;
+    padding: 0;
+  }
+
+  .prose a {
+    text-decoration: none;
+  }
+
+  /* Show where external links point since paper has no hover. */
+  .prose a[href^="http"]:not([href*="kirillbobyrev.com"])::after {
+    content: " (" attr(href) ")";
+    font-size: 0.85em;
+    vertical-align: baseline;
+    color: var(--color-muted);
+    word-break: break-all;
+  }
+
+  .highlight pre {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
 /* === Reduced motion === */
 @media (prefers-reduced-motion: reduce) {
   html {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -849,10 +849,11 @@ a.heading-anchor:hover {
 
 /* === Code === */
 .highlight {
+  /* Anchor for the language chip / copy button; the pre scrolls under them. */
+  position: relative;
   border-radius: var(--radius);
   border: 1px solid var(--color-border);
   margin-block: 1.5rem;
-  overflow-x: auto;
   background-color: var(--color-bg-code);
 }
 
@@ -863,6 +864,44 @@ a.heading-anchor:hover {
   font-size: var(--step--1);
   line-height: 1.55;
   background-color: transparent;
+  overflow-x: auto;
+}
+
+.code-lang,
+.code-copy {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.55rem;
+  font-family: var(--font-mono);
+  font-size: var(--step--2);
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.3rem 0.45rem;
+  border-radius: var(--radius-sm);
+  background-color: var(--color-bg-code);
+  color: var(--color-muted);
+  transition: opacity var(--transition);
+}
+
+.code-copy {
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+  opacity: 0;
+}
+
+.code-copy:hover {
+  color: var(--color-accent);
+}
+
+.highlight:hover .code-copy,
+.code-copy:focus-visible {
+  opacity: 1;
+}
+
+.highlight:hover .code-lang,
+.highlight:focus-within .code-lang {
+  opacity: 0;
 }
 
 code:not(pre code) {

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -42,5 +42,34 @@
         });
       })();
     </script>
+    {{- /* Code blocks: language chip + copy-to-clipboard button. */ -}}
+    <script>
+      (() => {
+        for (const block of document.querySelectorAll(".highlight")) {
+          const code = block.querySelector("pre code");
+          if (!code) continue;
+          const lang = code.dataset.lang;
+          if (lang && lang !== "text" && lang !== "fallback") {
+            const chip = document.createElement("span");
+            chip.className = "code-lang";
+            chip.textContent = lang;
+            block.append(chip);
+          }
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.className = "code-copy";
+          btn.textContent = "copy";
+          btn.setAttribute("aria-label", "Copy code to clipboard");
+          btn.addEventListener("click", async () => {
+            try {
+              await navigator.clipboard.writeText(code.textContent);
+              btn.textContent = "copied";
+              setTimeout(() => (btn.textContent = "copy"), 1500);
+            } catch (e) {}
+          });
+          block.append(btn);
+        }
+      })();
+    </script>
   </body>
 </html>

--- a/layouts/page.html
+++ b/layouts/page.html
@@ -25,5 +25,25 @@
       </details>
     {{- end -}}
     <div class="prose">{{ .Content }}</div>
+    {{- if or .PrevInSection .NextInSection -}}
+      <nav class="post-nav" aria-label="More posts">
+        {{- with .PrevInSection -}}
+          <a class="post-nav-link" rel="prev" href="{{ .RelPermalink }}">
+            <span class="post-nav-label">&larr; Older</span>
+            <span class="post-nav-title">{{ .Title }}</span>
+          </a>
+        {{- end -}}
+        {{- with .NextInSection -}}
+          <a
+            class="post-nav-link post-nav-newer"
+            rel="next"
+            href="{{ .RelPermalink }}"
+          >
+            <span class="post-nav-label">Newer &rarr;</span>
+            <span class="post-nav-title">{{ .Title }}</span>
+          </a>
+        {{- end -}}
+      </nav>
+    {{- end -}}
   </article>
 {{- end -}}

--- a/layouts/section.html
+++ b/layouts/section.html
@@ -1,25 +1,30 @@
 {{- define "main" -}}
   <article class="main-content">
     <h1>{{ .Title }}</h1>
-    <ul class="blog-timeline">
-      {{- range .Pages -}}
-        <li>
-          <a href="{{ .RelPermalink }}" class="blog-timeline-entry">
-            <time
-              datetime="{{ .Date.Format "2006-01-02" }}"
-              class="blog-timeline-date"
-              >{{ .Date.Format "Jan 02, 2006" }}</time
-            >
-            <span class="blog-timeline-content">
-              <span class="blog-timeline-title">{{ .Title }}</span>
-              {{- with .Description | default .Params.description -}}
-                <span class="blog-timeline-sep"> &mdash; </span>
-                <span class="blog-timeline-desc">{{ . }}</span>
-              {{- end -}}
-            </span>
-          </a>
-        </li>
-      {{- end -}}
-    </ul>
+    {{- range .Pages.GroupByDate "2006" }}
+      <section class="timeline-year">
+        <h2 class="timeline-year-label">{{ .Key }}</h2>
+        <ul class="blog-timeline">
+          {{- range .Pages -}}
+            <li>
+              <a href="{{ .RelPermalink }}" class="blog-timeline-entry">
+                <time
+                  datetime="{{ .Date.Format "2006-01-02" }}"
+                  class="blog-timeline-date"
+                  >{{ .Date.Format "Jan 02" }}</time
+                >
+                <span class="blog-timeline-content">
+                  <span class="blog-timeline-title">{{ .Title }}</span>
+                  {{- with .Description | default .Params.description -}}
+                    <span class="blog-timeline-sep"> &mdash; </span>
+                    <span class="blog-timeline-desc">{{ . }}</span>
+                  {{- end -}}
+                </span>
+              </a>
+            </li>
+          {{- end -}}
+        </ul>
+      </section>
+    {{- end }}
   </article>
 {{- end -}}


### PR DESCRIPTION
Ten independent improvements, one commit each, so any can be reverted in isolation. Explored and approved via an interactive configurator artifact.

## Reading & typography
- **`text-wrap: pretty` / `balance`** on prose and headings — no more one-word last lines, balanced heading wraps.
- **Dim images in dark mode** (−15% brightness, +5% contrast) so bright figures don't glow against the dark ground.
- **Themed scrollbars** via `scrollbar-color`, thin on code blocks and tables.

## Navigation & orientation
- **Older/newer post navigation** at the bottom of each post (`PrevInSection`/`NextInSection`, `rel` attributes included).
- **Year-grouped blog listing** (`GroupByDate "2006"`) with quiet overline year labels and short `Jan 02` dates.
- **Cross-document view transitions** — pages cross-fade in supporting browsers; instant everywhere else; disabled under `prefers-reduced-motion`.
- **Jump-target highlight** — following a TOC/footnote link briefly tints the destination element.

## Utility
- **Code blocks: language chip + copy button** — chip names the fence language, hover swaps it for a copy button (`textContent`, so Chroma's flex line-spans don't double newlines). Horizontal scrolling moved from `.highlight` to the inner `pre` so the controls stay anchored.
- **External-link arrows** — a small ↗ marks prose links that leave the site.
- **Print stylesheet** — chrome hidden, light palette forced, external URLs expanded inline, code wraps.

## Verification
- Verified in a real browser: year groups render, older/newer semantics correct, language chips + clipboard contents exact, toggle/theming unaffected.
- Production and drafts builds clean; all templates pass `npm run format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSRawJot9VBPZxX4RJy7cM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSRawJot9VBPZxX4RJy7cM)_