### PR TITLE
Add the /taste page and slim the footer crests to a teaser

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -373,7 +373,7 @@ video {
 
 .badges {
   display: flex;
-  gap: 0.9rem;
+  gap: 0.8rem;
   align-items: center;
 }
 
@@ -388,18 +388,15 @@ video {
   filter: none;
 }
 
-.badge svg,
 .badge img {
-  width: 25px;
-  height: 25px;
+  width: 30px;
+  height: 30px;
   object-fit: contain;
   display: block;
 }
 
-.badge-sep {
-  width: 1px;
-  height: 22px;
-  background-color: var(--color-border);
+.badges-link {
+  white-space: nowrap;
 }
 
 .footer-nav {
@@ -788,6 +785,112 @@ a.heading-anchor:hover {
 
 .home-recent-all:hover {
   color: var(--color-accent);
+}
+
+/* === Taste page === */
+.taste-lede {
+  margin: 0 0 0.75rem;
+  font-size: var(--step-1);
+  line-height: 1.5;
+  color: var(--color-muted);
+}
+
+.taste-overline {
+  margin: 1.5rem 0 0.9rem;
+  font-size: var(--step--1);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+}
+
+.crest-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(7.2rem, 1fr));
+  gap: 1.6rem 0.8rem;
+  margin-block: 1rem;
+}
+
+.crest-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+  text-align: center;
+}
+
+.crest-card img {
+  height: 84px;
+  width: auto;
+  max-width: 100%;
+  object-fit: contain;
+}
+
+.crest-name {
+  font-weight: 500;
+  color: var(--color-heading);
+  font-size: var(--step--1);
+  line-height: 1.3;
+}
+
+/* Theme-aware crest pairs (display cannot ride light-dark(), so this
+   follows the theme-icon pattern). */
+.crest-dark {
+  display: none;
+}
+
+:root[data-theme="dark"] .crest-dark {
+  display: block;
+}
+
+:root[data-theme="dark"] .crest-light {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .crest-dark {
+    display: block;
+  }
+
+  :root:not([data-theme="light"]) .crest-light {
+    display: none;
+  }
+}
+
+.crest-note {
+  color: var(--color-muted);
+  font-size: var(--step--2);
+  line-height: 1.35;
+}
+
+.taste-list {
+  list-style: none;
+  margin-block: 0.75rem;
+  padding: 0;
+}
+
+.taste-list li {
+  padding: 0.4rem 0.6rem;
+  margin-inline: -0.6rem;
+  border-radius: var(--radius);
+  transition: background-color var(--transition);
+}
+
+.taste-list li:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.taste-name {
+  font-weight: 500;
+  color: var(--color-heading);
+}
+
+.taste-sep,
+.taste-note {
+  color: var(--color-muted);
+}
+
+.taste-note {
+  font-size: var(--step--1);
 }
 
 /* === Blog timeline === */

--- a/content/taste.md
+++ b/content/taste.md
@@ -1,0 +1,5 @@
+---
+title: Taste
+description: Things I keep coming back to.
+layout: taste
+---

--- a/data/taste.toml
+++ b/data/taste.toml
@@ -1,0 +1,88 @@
+# Content for the /taste page. Add an item = add a table; the layout
+# (layouts/taste.html) renders everything here, no HTML edits needed.
+
+[football]
+
+  [[football.groups]]
+    label = 'Clubs'
+
+    [[football.groups.items]]
+      file = 'manchester-city.svg'
+      name = 'Manchester City'
+      note = 'fell in love with Guardiola'
+
+    [[football.groups.items]]
+      file = 'bayern-munich.svg'
+      name = 'Bayern Munich'
+      note = 'lived in Munich'
+
+    [[football.groups.items]]
+      file = 'chelsea.svg'
+      name = 'Chelsea'
+      note = 'Xabi Alonso'
+
+  [[football.groups]]
+    label = 'National teams'
+
+    [[football.groups.items]]
+      file = 'england.svg'
+      name = 'England'
+      note = 'Beckham, since ~2000'
+
+    [[football.groups.items]]
+      file = 'norway.svg'
+      name = 'Norway'
+      note = 'Haaland'
+
+    [[football.groups.items]]
+      file = 'germany.svg'
+      name = 'Germany'
+      note = 'lived in Munich'
+
+  [[football.groups]]
+    label = 'Competitions'
+
+    [[football.groups.items]]
+      # Placeholder logo. For a theme-aware pair, drop the files into
+      # static/crests/ and replace `file` with:
+      #   file_light = 'premier-league-on-light.svg'
+      #   file_dark = 'premier-league-on-dark.svg'
+      file = 'premier-league.svg'
+      name = 'Premier League'
+      note = 'since ~2000'
+
+[[sections]]
+  title = 'Stationery'
+
+  [[sections.items]]
+    name = 'rotring 800'
+    note = 'the drafting classic'
+
+  [[sections.items]]
+    name = 'CW&T Pen Type-B'
+    note = 'machined titanium, overbuilt on purpose'
+
+[[sections]]
+  title = 'Design'
+
+  [[sections.items]]
+    name = 'Newsreader & Inter'
+    note = 'the type on this site'
+
+  [[sections.items]]
+    name = 'JetBrains Mono'
+    note = 'every line of code here'
+
+# More section ideas, same shape as above:
+#
+# [[sections]]
+#   title = 'Chess'
+#   [[sections.items]]
+#     name = 'Blitz on chess.com'
+#     note = '...'
+#
+# [[sections]]
+#   title = 'Learning'
+#   [[sections.items]]
+#     name = 'Anki'
+#     note = 'spaced repetition that stuck'

--- a/layouts/_partials/badges.html
+++ b/layouts/_partials/badges.html
@@ -1,40 +1,19 @@
-{{- /* Football colours: club crests + national-team crests + competition logos. */ -}}
-{{- /* Crest SVGs are committed to static/crests/. */ -}}
-{{- $clubs := slice
-  (dict "file" "manchester-city.svg" "name" "Manchester City")
-  (dict "file" "bayern-munich.svg" "name" "Bayern Munich")
-  (dict "file" "liverpool.svg" "name" "Liverpool")
-  (dict "file" "chelsea.svg" "name" "Chelsea")
--}}
-{{- $nationals := slice
-  (dict "file" "england.svg" "name" "England")
-  (dict "file" "norway.svg" "name" "Norway")
-  (dict "file" "germany.svg" "name" "Germany")
--}}
+{{- /* Footer teaser for /taste: the two main crests plus a link to the rest. */ -}}
 <span class="badges">
-  {{- range $clubs -}}
-    <span class="badge" title="{{ .name }}">
+  {{- range slice
+    (dict "file" "manchester-city.svg" "name" "Manchester City")
+    (dict "file" "bayern-munich.svg" "name" "Bayern Munich")
+  -}}
+    <a href="/taste/" class="badge" title="{{ .name }}">
       <img
         src="/crests/{{ .file }}"
         alt="{{ .name }}"
         loading="lazy"
         decoding="async"
-        width="25"
-        height="25"
+        width="30"
+        height="30"
       />
-    </span>
+    </a>
   {{- end -}}
-  <span class="badge-sep" aria-hidden="true"></span>
-  {{- range $nationals -}}
-    <span class="badge" title="{{ .name }}">
-      <img
-        src="/crests/{{ .file }}"
-        alt="{{ .name }}"
-        loading="lazy"
-        decoding="async"
-        width="25"
-        height="25"
-      />
-    </span>
-  {{- end -}}
+  <a href="/taste/" class="badges-link">all of it &rarr;</a>
 </span>

--- a/layouts/taste.html
+++ b/layouts/taste.html
@@ -1,0 +1,59 @@
+{{- define "main" -}}
+  <article class="main-content">
+    <h1>{{ .Title }}</h1>
+    <p class="taste-lede">{{ .Description }}</p>
+    {{- $taste := hugo.Data.taste -}}
+
+
+    <h2>Football</h2>
+    {{- range $taste.football.groups }}
+      <p class="taste-overline">{{ .label }}</p>
+      <div class="crest-grid">
+        {{- range .items }}
+          <div class="crest-card">
+            {{- if and .file_light .file_dark }}
+              <img
+                class="crest-light"
+                src="/crests/{{ .file_light }}"
+                alt="{{ .name }} crest"
+                loading="lazy"
+                decoding="async"
+              />
+              <img
+                class="crest-dark"
+                src="/crests/{{ .file_dark }}"
+                alt="{{ .name }} crest"
+                loading="lazy"
+                decoding="async"
+              />
+            {{- else }}
+              <img
+                src="/crests/{{ .file }}"
+                alt="{{ .name }} crest"
+                loading="lazy"
+                decoding="async"
+              />
+            {{- end }}
+            <span class="crest-name">{{ .name }}</span>
+            {{- with .note }}<span class="crest-note">{{ . }}</span>{{ end }}
+          </div>
+        {{- end }}
+      </div>
+    {{- end }}
+
+    {{- range $taste.sections }}
+      <h2>{{ .title }}</h2>
+      <ul class="taste-list">
+        {{- range .items }}
+          <li>
+            <span class="taste-name">{{ .name }}</span>
+            {{- with .note }}
+              <span class="taste-sep">&mdash;</span>
+              <span class="taste-note">{{ . }}</span>
+            {{- end }}
+          </li>
+        {{- end }}
+      </ul>
+    {{- end }}
+  </article>
+{{- end -}}


### PR DESCRIPTION
A dedicated `/taste` page for personal favourites, replacing the cramped 25px crest strip in the footer. Design approved via the live mock artifact.

## The page

- **Football leads**: crests at 84px in full colour — Clubs (Manchester City, Bayern, Chelsea), National teams (England, Norway, Germany), and Competitions (Premier League, placeholder logo for now), each with a short personal note.
- **List sections** (Stationery, Design) share one grammar: bold name — muted one-line why.
- Everything is driven by `data/taste.toml`: adding an item or a whole section is a data edit, never an HTML change. Commented examples show the shape.
- Crest items support an optional `file_light`/`file_dark` pair rendered with the same theme-scope pattern as the header theme icons — ready for the themed Premier League logos to drop in.

## The footer

The Colours column becomes the doorway: Manchester City + Bayern at a legible 30px plus an "all of it →" link to `/taste/`. The Liverpool liverbird SVG (1:1.8 aspect ratio) was the "looks bad" culprit — it can never fit a 25px square; on the page, tall marks get room.

## Verification

- Clean build with `--printPathWarnings` (also caught and used the modern `hugo.Data` accessor — `.Site.Data` is deprecated since 0.156).
- Rendered page verified in a real browser in both themes; footer teaser links checked.
- Templates pass `npm run format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSRawJot9VBPZxX4RJy7cM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSRawJot9VBPZxX4RJy7cM)_