### PR TITLE
Add The Athletic FC to podcasts on /taste

### DIFF
--- a/data/taste.toml
+++ b/data/taste.toml
@@ -89,6 +89,9 @@
   [[sections.items]]
     name = 'Lex Fridman Podcast'
 
+  [[sections.items]]
+    name = 'The Athletic FC'
+
 [[sections]]
   title = 'Games'
 


### PR DESCRIPTION
One-line data change: The Athletic FC joins the Podcasts section on `/taste`. Verified in a clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSRawJot9VBPZxX4RJy7cM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSRawJot9VBPZxX4RJy7cM)_