### PR TITLE
Improve CI: Dependabot cooldowns/grouping + faster, hardened deploy workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,30 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
-  - package-ecosystem: "npm"
+    # Bundle all Action bumps into a single monthly PR instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Wait for a release to settle before proposing it, so freshly-published
+    # (and potentially compromised or broken) versions age first. Security
+    # updates ignore the cooldown and are still opened immediately.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+
+  - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: monthly
+    groups:
+      npm:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary

Improvements to the GitHub Actions dependency + build/deploy setup.

### Dependabot (`.github/dependabot.yml`) — pushed in this PR
- **Cooldowns**: freshly-published releases age before Dependabot proposes them (`default-days: 7`, `semver-major-days: 14`, `semver-minor-days: 7`, `semver-patch-days: 3`). Security updates bypass cooldowns and still open immediately. Ref: [default package cooldown changelog](https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/).
- **Grouping**: Actions and npm bumps are each grouped into a single monthly PR instead of one PR per package.

### Workflow (`.github/workflows/build-and-deploy.yml`) — NOT yet pushable here
The integration lacks the `workflows` permission (both git-over-HTTP and the GitHub API return 403 on workflow-file writes), so this change must be applied by the repo owner or after granting that permission. Intended changes:

- **Install the official prebuilt `hugo_extended` `.deb`** from the Hugo release page instead of compiling from source with `go install`. This is the approach in Hugo's own GitHub Pages docs: it drops the Go toolchain + CGO compile entirely (a ~1–2 min step becomes a few-second download), pulls the binary straight from the vendor (no third-party action in the trust chain), and still ships WebP encoding — the only extended feature this site uses (no Sass/SCSS present). Because there's no longer a slow compile, binary caching is unnecessary and is removed.
- **PR build validation**: add a `pull_request` trigger so every PR (including Dependabot's) builds the site and runs the link check; the `deploy` job and Pages upload are guarded to `push`/`schedule`/`workflow_dispatch` only.
- **Concurrency**: serialize deploys per-ref without cancelling an in-progress production deploy, while cancelling superseded PR builds.
- **Hardening / hygiene**: single `HUGO_VERSION` env var, `timeout-minutes` on both jobs, and `persist-credentials: false` on checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)