### PR TITLE
Add mathematical easter eggs to the design

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -599,17 +599,72 @@ video {
   margin-block: 0.3em;
 }
 
+/* Mathematical bullets: composition, then dot product, then convolution
+   the deeper the list nests. Browsers without ::marker keep the default
+   discs; both are fine. */
+.prose ul > li::marker {
+  content: "\2218\a0\a0"; /* ∘ */
+  color: var(--color-muted);
+}
+
+.prose ul ul > li::marker {
+  content: "\b7\a0\a0"; /* · */
+}
+
+.prose ul ul ul > li::marker {
+  content: "\2217\a0\a0"; /* ∗ */
+}
+
 .prose blockquote {
   font-style: italic;
   color: var(--color-muted);
   margin-block: 1.5rem;
   padding-inline: 1.5rem;
+  position: relative;
+}
+
+/* Turnstile: the quote is something asserted. */
+.prose blockquote::before {
+  content: "\22a2"; /* ⊢ */
+  position: absolute;
+  inset-inline-start: 0;
+  font-style: normal;
+  color: var(--color-underline);
 }
 
 .prose hr {
   border: 0;
   border-top: 1px solid var(--color-border);
   margin-block: 2.25rem;
+}
+
+/* === Post body easter eggs (single posts only, via .post-body) === */
+/* Section counters, like a paper: h2s get a quiet §n. */
+.post-body {
+  counter-reset: section;
+}
+
+.post-body h2 {
+  counter-increment: section;
+}
+
+.post-body h2::before {
+  content: "\a7" counter(section); /* §n */
+  margin-inline-end: 0.55rem;
+  font-family: var(--font-sans);
+  font-size: 0.68em;
+  font-weight: 500;
+  color: var(--color-muted);
+  vertical-align: 0.12em;
+}
+
+/* End of proof. */
+.post-body::after {
+  content: "\220e"; /* ∎ */
+  display: block;
+  text-align: end;
+  color: var(--color-muted);
+  margin-block-start: 2.25rem;
 }
 
 /* === Post navigation (older / newer) === */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -620,16 +620,6 @@ video {
   color: var(--color-muted);
   margin-block: 1.5rem;
   padding-inline: 1.5rem;
-  position: relative;
-}
-
-/* Turnstile: the quote is something asserted. */
-.prose blockquote::before {
-  content: "\22a2"; /* ⊢ */
-  position: absolute;
-  inset-inline-start: 0;
-  font-style: normal;
-  color: var(--color-underline);
 }
 
 .prose hr {
@@ -639,17 +629,9 @@ video {
 }
 
 /* === Post body easter eggs (single posts only, via .post-body) === */
-/* Section counters, like a paper: h2s get a quiet §n. */
-.post-body {
-  counter-reset: section;
-}
-
-.post-body h2 {
-  counter-increment: section;
-}
-
+/* A quiet section sign on h2s, like a paper. */
 .post-body h2::before {
-  content: "\a7" counter(section); /* §n */
+  content: "\a7"; /* § */
   margin-inline-end: 0.55rem;
   font-family: var(--font-sans);
   font-size: 0.68em;

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,7 +1,7 @@
 {{- define "main" -}}
   <article class="main-content error-page">
     <h1 class="error-title">404</h1>
-    <p>Sorry, the page you're looking for doesn't exist.</p>
+    <p>This URL &notin; kirillbobyrev.com &mdash; no such page exists.</p>
     <a href="/" class="error-button">← Back to Home</a>
   </article>
 {{- end -}}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,7 +1,7 @@
 {{- define "main" -}}
   <article class="main-content error-page">
     <h1 class="error-title">404</h1>
-    <p>This URL &notin; kirillbobyrev.com &mdash; no such page exists.</p>
+    <p>This URL &notin; kirillbobyrev.com.</p>
     <a href="/" class="error-button">← Back to Home</a>
   </article>
 {{- end -}}

--- a/layouts/page.html
+++ b/layouts/page.html
@@ -8,11 +8,15 @@
           <time class="article-date" datetime="{{ .Date.Format "2006-01-02" }}"
             >{{ .Date.Format "January 2, 2006" }}</time
           >
-          <span class="article-reading-time">{{ .ReadingTime }} min read</span>
+          <span class="article-reading-time"
+            >&approx;&nbsp;{{ .ReadingTime }} min</span
+          >
           {{- /* Show the git last-modified date only for real updates (>1 day after publish). */ -}}
           {{- if gt (sub .Lastmod.Unix .Date.Unix) 86400 -}}
-            <span class="article-updated"
-              >Updated {{ .Lastmod.Format "January 2, 2006" }}</span
+            <span
+              class="article-updated"
+              title="Updated {{ .Lastmod.Format "January 2, 2006" }}"
+              >&Delta; {{ .Lastmod.Format "January 2, 2006" }}</span
             >
           {{- end -}}
         </div>
@@ -24,7 +28,7 @@
         {{ .TableOfContents }}
       </details>
     {{- end -}}
-    <div class="prose">{{ .Content }}</div>
+    <div class="prose post-body">{{ .Content }}</div>
     {{- if or .PrevInSection .NextInSection -}}
       <nav class="post-nav" aria-label="More posts">
         {{- with .PrevInSection -}}


### PR DESCRIPTION
Quiet, math-native touches woven into the existing design — all pure CSS/markup, no JS, no new assets:

| Where | Egg |
|---|---|
| Bullet lists | Markers walk down an operator scale as they nest: `∘` (composition — the Hadamard nod), `·` (dot product), `∗` (convolution) |
| End of each post | Flush-right `∎` (QED tombstone) above the post nav |
| Reading time | `≈ 17 min` |
| Updated date | `Δ May 29, 2026` (plain "Updated …" kept in a `title` tooltip) |
| Post `h2`s | A quiet, unnumbered `§` in muted sans, like a paper |
| 404 | "This URL ∉ kirillbobyrev.com." |

Evaluated on a live local build (light + dark, real posts + the features demo); everything rendered cleanly in both themes, with the symbols sitting in the muted greys so they read as typography, not decoration.

Tried and dropped along the way:

- A display-size `∄` as the 404 title — the site fonts don't cover these glyphs, so display-size rendering depends entirely on the OS fallback font and looked cramped at 4rem. Text-size symbols (everything shipped here) are safe.
- A `⊢` turnstile before blockquotes and `§1…§n` heading counters — cut on review.

Browsers without `::marker` support keep the default bullets; no degradation elsewhere.

`hugo --gc --minify` builds clean; `npm run format:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5ehX1Lvm7dmoZmeUYc7p5