### PR TITLE
Move the section sign into the heading anchor; restore plain "Updated"

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -629,17 +629,6 @@ video {
 }
 
 /* === Post body easter eggs (single posts only, via .post-body) === */
-/* A quiet section sign on h2s, like a paper. */
-.post-body h2::before {
-  content: "\a7"; /* § */
-  margin-inline-end: 0.55rem;
-  font-family: var(--font-sans);
-  font-size: 0.68em;
-  font-weight: 500;
-  color: var(--color-muted);
-  vertical-align: 0.12em;
-}
-
 /* End of proof. */
 .post-body::after {
   content: "\220e"; /* ∎ */

--- a/layouts/_markup/render-heading.html
+++ b/layouts/_markup/render-heading.html
@@ -5,7 +5,7 @@
       href="#{{ .Anchor | safeURL }}"
       class="heading-anchor"
       aria-label="Link to this section"
-      >#</a
+      >&sect;</a
     >
   {{- end -}}
 </h{{ .Level }}>

--- a/layouts/page.html
+++ b/layouts/page.html
@@ -13,10 +13,8 @@
           >
           {{- /* Show the git last-modified date only for real updates (>1 day after publish). */ -}}
           {{- if gt (sub .Lastmod.Unix .Date.Unix) 86400 -}}
-            <span
-              class="article-updated"
-              title="Updated {{ .Lastmod.Format "January 2, 2006" }}"
-              >&Delta; {{ .Lastmod.Format "January 2, 2006" }}</span
+            <span class="article-updated"
+              >Updated {{ .Lastmod.Format "January 2, 2006" }}</span
             >
           {{- end -}}
         </div>


### PR DESCRIPTION
Two follow-ups to the easter-egg PR (#78):

- The `§` was meant to *be* the hover anchor link after headings, not a prefix before them: `render-heading.html` now emits `§` as the anchor glyph (replacing `#`), and the `h2::before` prefix CSS is gone. Headings render as `Lists §` on hover, with the same muted styling and behavior as before.
- The `Δ` on the last-modified label reverts to the word "Updated" — too cryptic next to a date.

Verified on a live local build; `hugo --gc --minify` and `npm run format:check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5ehX1Lvm7dmoZmeUYc7p5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ehX1Lvm7dmoZmeUYc7p5)_