### PR TITLE
Overhaul CI: PR validation, fast pinned Hugo installs, online link checks

### DIFF
--- a/.github/actions/setup-hugo/action.yml
+++ b/.github/actions/setup-hugo/action.yml
@@ -1,0 +1,34 @@
+name: Setup Hugo
+description: >-
+  Install the pinned Hugo extended release binary with checksum
+  verification. This is the single source of truth for the Hugo version
+  in CI; keep .devcontainer/devcontainer.json in sync when bumping.
+  The extended build ships SASS + WebP encoding, same as the old
+  `go install -tags extended` path, but installs in seconds instead of
+  compiling for minutes.
+
+inputs:
+  version:
+    description: Hugo version to install (no leading v)
+    required: false
+    default: '0.164.0'
+
+runs:
+  using: composite
+  steps:
+    - name: Download, verify, and install Hugo
+      shell: bash
+      env:
+        HUGO_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        cd "$RUNNER_TEMP"
+        base="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}"
+        tarball="hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+        checksums="hugo_${HUGO_VERSION}_checksums.txt"
+        curl -sSfL --retry 3 --retry-delay 2 -O "${base}/${tarball}"
+        curl -sSfL --retry 3 --retry-delay 2 -O "${base}/${checksums}"
+        grep "  ${tarball}\$" "${checksums}" | sha256sum -c -
+        tar -xzf "${tarball}" hugo
+        sudo install -m 0755 hugo /usr/local/bin/hugo
+        hugo version

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,8 +4,17 @@ on:
   push:
     branches:
       - main
+    # Skip deploys for changes that cannot affect the built site.
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+      - '.devcontainer/**'
+      - '.mcp.json'
+      - '.prettierrc'
+      - '.prettierignore'
+      - '.github/dependabot.yml'
   schedule:
-    - cron: '0 0 * * 0'  # Runs at 00:00 UTC every Sunday
+    - cron: '0 0 * * 0' # Weekly rebuild: refreshes the fetched resume.
   workflow_dispatch:
 
 permissions:
@@ -13,9 +22,12 @@ permissions:
   pages: write
   id-token: write
 
+# Queue deploys instead of cancelling in-flight ones: with
+# cancel-in-progress a merge landing during a deploy killed it and left
+# the site on the previous build until something else triggered a run.
 concurrency:
-  group: "pages"
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 defaults:
   run:
@@ -24,22 +36,26 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history so enableGitInfo lastmod dates are correct
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
+      - name: Setup Hugo
+        uses: ./.github/actions/setup-hugo
 
-      - name: Install Hugo (extended, pinned)
-        # Keep the version in sync with .devcontainer; bump deliberately.
-        # -tags extended is required for WebP image encoding.
-        run: |
-          CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v0.164.0
+      - name: Restore generated-image cache
+        # resources/ holds Hugo's processed images (OG cards, responsive
+        # WebP sets). Restoring it skips re-encoding unchanged images;
+        # `hugo --gc` prunes entries that no longer correspond to content.
+        uses: actions/cache@v4
+        with:
+          path: resources
+          key: hugo-resources-${{ hashFiles('assets/**', 'content/**', 'layouts/**') }}
+          restore-keys: |
+            hugo-resources-
 
       - name: Setup Pages
         id: pages
@@ -50,7 +66,14 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p static
-          gh release download --repo kirillbobyrev/resume --pattern "Kirill-Bobyrev-Resume.pdf" --output static/resume.pdf --clobber
+          for attempt in 1 2 3; do
+            gh release download --repo kirillbobyrev/resume \
+              --pattern "Kirill-Bobyrev-Resume.pdf" \
+              --output static/resume.pdf --clobber && break
+            [ "$attempt" = 3 ] && exit 1
+            sleep $((attempt * 5))
+          done
+          test -s static/resume.pdf
 
       - name: Build with Hugo
         env:
@@ -79,7 +102,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+      - name: Summary
+        run: |
+          echo "Deployed \`${GITHUB_SHA}\` to ${{ steps.deployment.outputs.page_url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+# Pull-request validation: the site must build, internal links must
+# resolve, and templates must be Prettier-clean. Deploys never run here.
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build and check links
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # full history so enableGitInfo lastmod dates are correct
+
+      - name: Setup Hugo
+        uses: ./.github/actions/setup-hugo
+
+      - name: Fetch resume PDF
+        # A placeholder keeps the /resume.pdf link satisfied for the
+        # offline link check if the release fetch fails (e.g. fork PRs).
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p static
+          gh release download --repo kirillbobyrev/resume \
+            --pattern "Kirill-Bobyrev-Resume.pdf" \
+            --output static/resume.pdf --clobber \
+            || printf '%%PDF-1.4\n%%%% placeholder for CI\n' > static/resume.pdf
+
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo --gc --minify
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2.8.0
+        with:
+          args: --offline --no-progress --root-dir ./public ./public
+          fail: true
+
+  format:
+    name: Check formatting
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Check Prettier formatting
+        run: |
+          npm ci
+          npm run format:check

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,87 @@
+name: Link check
+
+# Weekly *online* link check: the deploy pipeline only checks links
+# offline (internal anchors and files), so external link rot would
+# otherwise go unnoticed. Failures file (or update) an issue instead of
+# failing a deploy.
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: link-check
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  online:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Hugo
+        uses: ./.github/actions/setup-hugo
+
+      - name: Fetch resume PDF
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p static
+          gh release download --repo kirillbobyrev/resume \
+            --pattern "Kirill-Bobyrev-Resume.pdf" \
+            --output static/resume.pdf --clobber \
+            || printf '%%PDF-1.4\n%%%% placeholder for CI\n' > static/resume.pdf
+
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo --gc --minify
+
+      - name: Check external links
+        id: lychee
+        uses: lycheeverse/lychee-action@v2.8.0
+        with:
+          # 429 is accepted: rate-limited hosts are not broken links.
+          # Big social networks are excluded because they answer bots
+          # with 403/999 regardless of whether the link works.
+          args: >-
+            --no-progress
+            --root-dir ./public
+            --accept 200..=206,429
+            --exclude linkedin\.com
+            --exclude twitter\.com
+            --exclude x\.com
+            --exclude instagram\.com
+            ./public
+          output: lychee-report.md
+          fail: false
+
+      - name: File or update the link-rot issue
+        if: steps.lychee.outputs.exit_code != 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="Link check: broken external links"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title \"$title\"" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" \
+              --body-file lychee-report.md
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" \
+              --body-file lychee-report.md
+          fi

--- a/README.md
+++ b/README.md
@@ -3,8 +3,13 @@
 [![Build and deploy](https://github.com/kirillbobyrev/kirillbobyrev.com/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/kirillbobyrev/kirillbobyrev.com/actions/workflows/build-and-deploy.yml)
 
 My personal website built with [Hugo](https://gohugo.io) (extended, pinned to
-`0.164.0` — see `.github/workflows/build-and-deploy.yml` and
+`0.164.0` — see `.github/actions/setup-hugo/action.yml` and
 `.devcontainer/devcontainer.json`).
+
+CI: pull requests build the site, validate internal links, and check
+formatting (`.github/workflows/ci.yml`); merges to `main` build and deploy to
+GitHub Pages (`build-and-deploy.yml`); a weekly job checks external links
+online and files an issue on rot (`link-check.yml`).
 
 ## Develop
 


### PR DESCRIPTION
## New: `ci.yml` — pull requests finally get checks

Every PR now builds the site with production settings, runs the offline lychee link check, and verifies Prettier formatting. Until now a broken template could only fail *after* merge, during deploy. Per-branch concurrency cancels superseded runs.

## New: `.github/actions/setup-hugo` composite action

Installs the pinned Hugo extended release binary with sha256 verification against Hugo's published checksums file — replacing the `go install -tags extended` step that compiled Hugo from source with CGO on every run (minutes → seconds; same extended features, WebP included). The action is now the single source of truth for the version pin; README points there.

## New: `link-check.yml` — weekly online link check

The deploy pipeline only checks links offline, so external link rot was invisible. This runs lychee online against the built site every Monday (and on dispatch), accepts 429s, excludes bot-hostile social networks (LinkedIn/Twitter/X/Instagram), and files — or appends to — a single "broken external links" issue instead of failing deploys.

## Hardened: `build-and-deploy.yml`

- **Concurrency queues instead of cancelling** (`cancel-in-progress: false`) — merging during an in-flight deploy previously cancelled it and stranded the live site on a stale build (this exact scenario happened with #79/#80 today).
- **Path filters**: README/LICENSE/devcontainer/tool-config changes no longer trigger deploys.
- **Resume fetch** retries 3× with backoff and asserts the file is non-empty.
- **Image cache**: Hugo's `resources/` (OG cards, responsive WebP sets) is restored across runs, keyed on content/assets/layouts; `--gc` prunes stale entries.
- **Timeouts** on both jobs; the deploy job writes a run summary with the deployed SHA and page URL.

## Verification

- All workflows pass `actionlint`; YAML parses clean.
- The checksum-verification shell logic was exercised locally against both the matching and tampered-tarball cases.
- The composite action can't be fully exercised outside Actions (this sandbox can't reach GitHub releases), so the first CI run on this PR is the real end-to-end test — conveniently, this PR triggers the new `ci.yml` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5ehX1Lvm7dmoZmeUYc7p5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q5ehX1Lvm7dmoZmeUYc7p5)_