### PR TITLE
Header redesign, post summaries, and a back-to-top control

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -256,62 +256,116 @@ video {
   max-width: var(--measure);
   margin-inline: auto;
   padding: 1.5rem;
+  padding-block-end: 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+  margin-block-end: 2rem;
+}
+
+/* Wraps so the title can take a line of its own on narrow screens (see the
+   responsive block); on wider screens the title and nav share one line. */
+.header-inner {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   justify-content: space-between;
+  column-gap: 1.5rem;
+  row-gap: 0.6rem;
 }
 
 .site-title {
   font-family: var(--font-serif);
-  font-size: var(--step-1);
+  font-size: var(--step-2);
   font-weight: 600;
+  line-height: 1.15;
   color: var(--color-heading);
   text-decoration: none;
-  letter-spacing: -0.005em;
+  letter-spacing: -0.015em;
+  transition: color var(--transition);
 }
 
 .site-title:hover {
   color: var(--color-accent);
 }
 
-.site-nav {
+.header-tools {
   display: flex;
-  align-items: baseline;
-  gap: 1.5rem;
+  align-items: center;
+  gap: 0.15rem;
+  margin-inline-start: auto;
+}
+
+.site-nav {
+  min-width: 0;
+}
+
+.nav-list {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
 }
 
 .nav-link {
+  display: block;
   color: var(--color-muted);
   text-decoration: none;
-  padding-block: 0.15rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: var(--radius-sm);
   font-size: var(--step-0);
   font-weight: 500;
-  transition: color var(--transition);
+  transition:
+    color var(--transition),
+    background-color var(--transition);
 }
 
 .nav-link:hover {
-  color: var(--color-accent);
+  color: var(--color-heading);
+  background-color: var(--color-bg-hover);
 }
 
+/* The rule hugs the label rather than the padded hit area: painting it as a
+   background image anchored to the content box keeps it under the text
+   whatever the padding is, while background-color stays free for the hover
+   pill (which fills the whole tap target). */
 .nav-link[aria-current] {
   color: var(--color-heading);
-  box-shadow: inset 0 -2px 0 var(--color-sky);
+  background-image: linear-gradient(var(--color-sky), var(--color-sky));
+  background-repeat: no-repeat;
+  background-size: 100% 2px;
+  background-position: bottom;
+  background-origin: content-box;
 }
 
 .theme-toggle {
-  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 0;
-  padding: 0.25rem;
-  margin: -0.25rem 0;
+  padding: 0.4rem;
+  margin-inline-start: 0.2rem;
+  border-radius: var(--radius-sm);
   background: none;
   color: var(--color-muted);
   cursor: pointer;
   line-height: 0;
-  transition: color var(--transition);
+  transition:
+    color var(--transition),
+    background-color var(--transition);
 }
 
 .theme-toggle:hover {
-  color: var(--color-accent);
+  color: var(--color-heading);
+  background-color: var(--color-bg-hover);
+}
+
+/* An author-origin `display` beats the UA's `[hidden] { display: none }`
+   regardless of specificity, so restore it: the button ships hidden and only
+   the theme script unhides it, keeping it away from no-JS readers. */
+.theme-toggle[hidden] {
+  display: none;
 }
 
 .theme-icon-sun {
@@ -1369,16 +1423,43 @@ pre.mermaid svg {
 /* === Responsive === */
 @media (max-width: 640px) {
   .site-header {
-    padding: 1rem;
+    padding: 1.25rem 1rem 0.6rem;
+    margin-block-end: 1.5rem;
   }
 
+  /* Title gets the full first line, so it can carry the page the way a
+     masthead should instead of competing with the links for width. */
+  .site-title {
+    flex-basis: 100%;
+    font-size: var(--step-3);
+  }
+
+  .header-tools {
+    width: 100%;
+    margin-inline-start: 0;
+  }
+
+  /* Nav starts under the title and scrolls sideways rather than wrapping or
+     shrinking, so links stay tappable however many of them there are. The
+     toggle sits outside this box, so it stays put as the links scroll. */
   .site-nav {
-    gap: 1rem;
+    flex: 1 1 auto;
+    overflow-x: auto;
+    scrollbar-width: none;
+    /* Room for the underline so it never clips against the border. */
+    padding-block-end: 0.15rem;
+  }
+
+  .site-nav::-webkit-scrollbar {
+    display: none;
   }
 
   .nav-link {
-    font-size: var(--step--1);
-    padding-block: 0.4rem;
+    padding: 0.45rem 0.55rem;
+  }
+
+  .theme-toggle {
+    padding: 0.45rem;
   }
 
   .site-container {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -287,15 +287,17 @@ video {
   color: var(--color-accent);
 }
 
-.header-tools {
+.header-brand {
   display: flex;
   align-items: center;
-  gap: 0.15rem;
-  margin-inline-start: auto;
+  gap: 0.35rem;
 }
 
+/* Cancels the links' own inline padding so their labels — not their tap
+   areas — line up with the title above and the text column below. */
 .site-nav {
   min-width: 0;
+  margin-inline: -0.55rem;
 }
 
 .nav-list {
@@ -345,7 +347,6 @@ video {
   justify-content: center;
   border: 0;
   padding: 0.4rem;
-  margin-inline-start: 0.2rem;
   border-radius: var(--radius-sm);
   background: none;
   color: var(--color-muted);
@@ -1427,23 +1428,27 @@ pre.mermaid svg {
     margin-block-end: 1.5rem;
   }
 
-  /* Title gets the full first line, so it can carry the page the way a
+  /* The name gets the full first line, so it can carry the page the way a
      masthead should instead of competing with the links for width. */
-  .site-title {
+  .header-brand {
     flex-basis: 100%;
+  }
+
+  .site-title {
     font-size: var(--step-3);
   }
 
-  .header-tools {
-    width: 100%;
-    margin-inline-start: 0;
+  .theme-toggle {
+    margin-inline-start: auto;
+    /* Pull the icon out to the text column's edge, past its own padding. */
+    margin-inline-end: -0.45rem;
+    padding: 0.45rem;
   }
 
   /* Nav starts under the title and scrolls sideways rather than wrapping or
-     shrinking, so links stay tappable however many of them there are. The
-     toggle sits outside this box, so it stays put as the links scroll. */
+     shrinking, so links stay tappable however many of them there are. */
   .site-nav {
-    flex: 1 1 auto;
+    width: 100%;
     overflow-x: auto;
     scrollbar-width: none;
     /* Room for the underline so it never clips against the border. */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1249,6 +1249,69 @@ a.taste-name {
   color: var(--color-accent);
 }
 
+/* Index only: the homepage list stays title-only, since it is a teaser
+   under a page of prose rather than somewhere you pick what to read. */
+.blog-timeline-summary {
+  display: block;
+  margin-block-start: 0.1rem;
+  color: var(--color-muted);
+  font-size: var(--step--1);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+/* === Back to top ===
+   Rendered only on long posts (see page.html) and revealed once the article
+   header has scrolled away, so it never sits over a screen you can already
+   see the top of. */
+.to-top {
+  position: fixed;
+  inset-block-end: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  inset-inline-end: 1.25rem;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  /* The stronger hairline, not --color-border: this floats over the page
+     rather than dividing it, and at --color-border it reads as a smudge
+     against a background of exactly the same colour. */
+  border: 1px solid var(--color-underline);
+  border-radius: var(--radius);
+  /* Opaque, so prose scrolling underneath never shows through. */
+  background-color: var(--color-bg);
+  color: var(--color-muted);
+  text-decoration: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0.35rem);
+  transition:
+    opacity var(--transition),
+    visibility var(--transition),
+    transform var(--transition),
+    color var(--transition),
+    background-color var(--transition),
+    border-color var(--transition);
+}
+
+.to-top[data-visible] {
+  opacity: 1;
+  visibility: visible;
+  transform: none;
+}
+
+.to-top:hover {
+  color: var(--color-heading);
+  background-color: var(--color-bg-hover);
+}
+
+/* Author-origin `display` outranks the UA's `[hidden]` rule, same as the
+   theme toggle: the link ships hidden and only the script reveals it. */
+.to-top[hidden] {
+  display: none;
+}
+
 /* === Figures === */
 .figure-block {
   margin-block: var(--space-block);
@@ -1519,7 +1582,8 @@ pre.mermaid svg {
   .site-footer,
   .back-link,
   .toc,
-  .post-nav {
+  .post-nav,
+  .to-top {
     display: none;
   }
 

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -1,33 +1,9 @@
 <header class="site-header">
   {{- /* Two flex lines by design: on narrow screens the title claims a full row on its own (see .site-title flex-basis in the responsive block) and the nav wraps beneath it; on wider screens both share one line. */ -}}
   <div class="header-inner">
-    <a href="/" class="site-title">{{ site.Title }}</a>
-    <div class="header-tools">
-      <nav class="site-nav" aria-label="Main">
-        <ul class="nav-list">
-          <li>
-            <a
-              href="/"
-              class="nav-link"
-              {{ if .IsHome }}aria-current="page"{{ end }}
-              >Home</a
-            >
-          </li>
-          {{- range .Site.Menus.main -}}
-            <li>
-              <a
-                href="{{ .URL }}"
-                class="nav-link"
-                {{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }}
-                  aria-current="page"
-                {{ end }}
-                >{{ .Name }}</a
-              >
-            </li>
-          {{- end -}}
-        </ul>
-      </nav>
-      {{- /* Outside <nav>: it's a display control, not navigation — and keeping it out of the scroll container pins it to the edge on narrow screens. */ -}}
+    <div class="header-brand">
+      <a href="/" class="site-title">{{ site.Title }}</a>
+      {{- /* Sits with the name, PaperMod-style: it's a display control rather than navigation, and keeping it out of the nav leaves the links free to align with the text column. */ -}}
       <button
         type="button"
         class="theme-toggle"
@@ -62,5 +38,29 @@
         </svg>
       </button>
     </div>
+    <nav class="site-nav" aria-label="Main">
+      <ul class="nav-list">
+        <li>
+          <a
+            href="/"
+            class="nav-link"
+            {{ if .IsHome }}aria-current="page"{{ end }}
+            >Home</a
+          >
+        </li>
+        {{- range .Site.Menus.main -}}
+          <li>
+            <a
+              href="{{ .URL }}"
+              class="nav-link"
+              {{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }}
+                aria-current="page"
+              {{ end }}
+              >{{ .Name }}</a
+            >
+          </li>
+        {{- end -}}
+      </ul>
+    </nav>
   </div>
 </header>

--- a/layouts/_partials/header.html
+++ b/layouts/_partials/header.html
@@ -1,54 +1,66 @@
 <header class="site-header">
-  <a href="/" class="site-title">Kirill Bobyrev</a>
-  <nav class="site-nav" aria-label="Main">
-    <a
-      href="/"
-      class="nav-link"
-      {{ if .IsHome }}aria-current="page"{{ end }}
-      >Home</a
-    >
-    {{- range .Site.Menus.main -}}
-      <a
-        href="{{ .URL }}"
-        class="nav-link"
-        {{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }}
-          aria-current="page"
-        {{ end }}
-        >{{ .Name }}</a
+  {{- /* Two flex lines by design: on narrow screens the title claims a full row on its own (see .site-title flex-basis in the responsive block) and the nav wraps beneath it; on wider screens both share one line. */ -}}
+  <div class="header-inner">
+    <a href="/" class="site-title">{{ site.Title }}</a>
+    <div class="header-tools">
+      <nav class="site-nav" aria-label="Main">
+        <ul class="nav-list">
+          <li>
+            <a
+              href="/"
+              class="nav-link"
+              {{ if .IsHome }}aria-current="page"{{ end }}
+              >Home</a
+            >
+          </li>
+          {{- range .Site.Menus.main -}}
+            <li>
+              <a
+                href="{{ .URL }}"
+                class="nav-link"
+                {{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }}
+                  aria-current="page"
+                {{ end }}
+                >{{ .Name }}</a
+              >
+            </li>
+          {{- end -}}
+        </ul>
+      </nav>
+      {{- /* Outside <nav>: it's a display control, not navigation — and keeping it out of the scroll container pins it to the edge on narrow screens. */ -}}
+      <button
+        type="button"
+        class="theme-toggle"
+        aria-label="Toggle dark mode"
+        hidden
       >
-    {{- end -}}
-    <button
-      type="button"
-      class="theme-toggle"
-      aria-label="Toggle dark mode"
-      hidden
-    >
-      <svg
-        class="theme-icon-sun"
-        width="17"
-        height="17"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="4.5" />
-        <path
-          d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8"
-        />
-      </svg>
-      <svg
-        class="theme-icon-moon"
-        width="17"
-        height="17"
-        viewBox="0 0 24 24"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
-      </svg>
-    </button>
-  </nav>
+        <svg
+          class="theme-icon-sun"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="4.5" />
+          <path
+            d="M12 2v2.5M12 19.5V22M2 12h2.5M19.5 12H22M4.9 4.9l1.8 1.8M17.3 17.3l1.8 1.8M19.1 4.9l-1.8 1.8M6.7 17.3l-1.8 1.8"
+          />
+        </svg>
+        <svg
+          class="theme-icon-moon"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+        </svg>
+      </button>
+    </div>
+  </div>
 </header>

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -60,6 +60,21 @@
         }
       })();
     </script>
+    {{- /* Back-to-top: reveal it once the article header has scrolled off. */ -}}
+    <script>
+      (() => {
+        const link = document.querySelector(".to-top");
+        if (!link) return;
+        const anchor = document.querySelector(".article-header");
+        if (!anchor) return;
+        link.hidden = false;
+        // Observing the header rather than listening to scroll: this fires
+        // twice per crossing instead of on every frame of every scroll.
+        new IntersectionObserver(([entry]) => {
+          link.toggleAttribute("data-visible", !entry.isIntersecting);
+        }).observe(anchor);
+      })();
+    </script>
     {{- /* Code blocks: language chip + copy-to-clipboard button. */ -}}
     <script>
       (() => {

--- a/layouts/page.html
+++ b/layouts/page.html
@@ -27,6 +27,26 @@
       </details>
     {{- end -}}
     <div class="prose post-body">{{ .Content }}</div>
+    {{- /* Same length gate as the contents block above: a post long enough to need a map is long enough to need a way back. */ -}}
+    {{- if ge .WordCount 1500 -}}
+      {{- /* "#top" rather than "#content": with no element of that id, browsers resolve it to the top of the document, so the masthead comes back too. */ -}}
+      <a href="#top" class="to-top" hidden>
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 19V5M5 12l7-7 7 7" />
+        </svg>
+        <span class="visually-hidden">Back to top</span>
+      </a>
+    {{- end -}}
     {{- if or .PrevInSection .NextInSection -}}
       <nav class="post-nav" aria-label="More posts">
         {{- with .PrevInSection -}}

--- a/layouts/section.html
+++ b/layouts/section.html
@@ -15,6 +15,9 @@
                 >
                 <span class="blog-timeline-content">
                   <span class="blog-timeline-title">{{ .Title }}</span>
+                  {{- with .Description -}}
+                    <span class="blog-timeline-summary">{{ . }}</span>
+                  {{- end -}}
                 </span>
               </a>
             </li>


### PR DESCRIPTION
A design pass over the header, plus two smaller additions that use content the site already carries.

**Live before/after demo of the header:** https://claude.ai/code/artifact/87a0f244-a087-497f-a367-6b3fa2ae8a31 — both the old and new headers run the real CSS inside a container query, so a width scrubber reflows them at the same 640 px breakpoint the site uses.

## Header

The site title sat at `--step-1` (20 px) beside the links on one cramped row at every width, so on a phone the name read as a fourth nav item rather than the masthead. This borrows Hugo PaperMod's header structure and adapts it to the existing type scale and colour tokens.

| | |
|---|---|
| **Title size** | `--step-1` → `--step-2`, and `--step-3` below 640 px, where it claims a full row of its own with the nav beneath it. On a phone that is 20 px → 29 px. |
| **Nav markup** | Bare anchors became a list of links — PaperMod's structure, and what a screen reader expects from a menu. |
| **Hit areas** | Padded links with a hover pill: 42 px tall on mobile, up from ~24. The old mobile rule also shrank labels to `--step--1`; they stay at `--step-0` now. |
| **Alignment** | That padding also pushed the labels inward, so the nav row started 9 px right of the name above it and the prose below it. A matching negative inline margin on the nav puts the labels back on the text column — first label to the left edge on mobile, last label to the right edge on desktop — while the tap areas keep their padding. |
| **Overflow** | The nav scrolls sideways instead of wrapping or shrinking, so links keep their size however many there are. |
| **Theme toggle** | Sits beside the name, where PaperMod keeps it, rather than trailing the links. On a phone it takes the far end of the masthead row, so the nav row below holds nothing but navigation; its icon hangs past its own padding to sit flush with the column edge. |
| **Active rule** | Painted as a background image anchored to the content box, so it hugs the label instead of stretching across the new padding. |
| **Hairline** | A border under the header brackets the page against the rule the footer already has. |

Title text now comes from `site.Title` instead of being hardcoded.

## Post summaries on the blog index

Every post already has a `description` in its front matter that nothing rendered. The index now prints it under the title, so it says what a post is about rather than only what it is called. The homepage list deliberately stays title-only — it is a teaser at the end of a page of prose, not somewhere you choose what to read.

## Back-to-top on long posts

Behind the same word-count gate as the contents block, so today only the chess post gets it. It reveals itself once the article header has scrolled away, via an `IntersectionObserver` on the header rather than a scroll listener, so nothing runs per frame. Two details worth noting:

- It targets `#top`, not `#content`. `#content` is the `<main>` element, which sits below the header, so "back to top" landed 147 px down the page. With no element of that id, browsers resolve `#top` to the top of the document, and the masthead comes back with it.
- It takes `--color-underline` rather than `--color-border`. The button's fill is the page's own background colour, so at `--color-border` the outline was effectively invisible in both themes.

## Testing

Rendered under headless Chromium against `hugo server`:

- Home, blog index, and posts at 390 px and 1440 px, light and dark.
- Widths 320 / 360 / 480 / 640 / 768: no horizontal overflow of the page body at any of them, nav link height 42 px on mobile.
- Header alignment measured off text ranges rather than boxes: at 390 px the title, the first nav label, and the body copy all start at x=17; at 1440 px the last nav label ends on the column's right edge.
- Nav overflow with a padded-out menu (7 items at 320 px): the nav scrolls and the toggle stays put.
- Summaries render on the index (2 of 2 entries) and not on the homepage teaser (0).
- Back-to-top: absent on the short post, present on the long one; opacity 0 at the top, 1 after scrolling, inside the viewport, and clicking it lands at `scrollY === 0`.
- Theme toggle still flips and persists; `:focus-visible` rings the padded link; tab order runs name → toggle → links, matching the visual order.
- **No-JS:** an author-origin `display` beats the UA's `[hidden] { display: none }` regardless of specificity, which would have leaked both the theme toggle and the back-to-top link to no-JS readers. Both now carry an explicit `[hidden] { display: none }`, verified with JavaScript disabled.
- No console or page errors on any route; `hugo --gc --minify` clean; `prettier --check` clean on templates and CSS.