### PR TITLE
Add a /now page, and centre the theme toggle on the title's caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build and deploy](https://github.com/kirillbobyrev/kirillbobyrev.com/actions/workflows/build-and-deploy.yml/badge.svg)](https://github.com/kirillbobyrev/kirillbobyrev.com/actions/workflows/build-and-deploy.yml)
 
 My personal website built with [Hugo](https://gohugo.io) (extended, pinned to
-`0.164.0` — see `.github/actions/setup-hugo/action.yml` and
+`0.164.0` - see `.github/actions/setup-hugo/action.yml` and
 `.devcontainer/devcontainer.json`).
 
 CI: pull requests build the site, validate internal links, and check

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -296,8 +296,8 @@ video {
   gap: 0.35rem;
 }
 
-/* Cancels the links' own inline padding so their labels — not their tap
-   areas — line up with the title above and the text column below. */
+/* Cancels the links' own inline padding so their labels - not their tap
+   areas - line up with the title above and the text column below. */
 .site-nav {
   min-width: 0;
   margin-inline: -0.55rem;
@@ -356,10 +356,10 @@ video {
   cursor: pointer;
   line-height: 0;
   /* `align-items: center` centres the icon on the title's line box, but a
-     Title Case name reads as its cap band — baseline up to cap top — which
+     Title Case name reads as its cap band - baseline up to cap top - which
      sits higher, so a symmetrical icon looks low beside it. Lift it onto the
      cap-band centre. The factor is measured against rendered pixels: the gap
-     between the two centres is 0.10–0.13 of the title's size, drifting a
+     between the two centres is 0.10-0.13 of the title's size, drifting a
      little because Chromium rounds font ascent and descent to whole pixels
      when it places the baseline. Transform, so the row's height is unchanged. */
   translate: 0 calc(var(--title-size, var(--step-2)) * -0.115);

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -274,7 +274,7 @@ video {
 
 .site-title {
   font-family: var(--font-serif);
-  font-size: var(--step-2);
+  font-size: var(--title-size);
   font-weight: 600;
   line-height: 1.15;
   color: var(--color-heading);
@@ -288,6 +288,9 @@ video {
 }
 
 .header-brand {
+  /* Drives the title's size and the toggle's optical lift together, so the
+     two can't drift apart when one breakpoint changes the type scale. */
+  --title-size: var(--step-2);
   display: flex;
   align-items: center;
   gap: 0.35rem;
@@ -352,6 +355,14 @@ video {
   color: var(--color-muted);
   cursor: pointer;
   line-height: 0;
+  /* `align-items: center` centres the icon on the title's line box, but a
+     Title Case name reads as its cap band — baseline up to cap top — which
+     sits higher, so a symmetrical icon looks low beside it. Lift it onto the
+     cap-band centre. The factor is measured against rendered pixels: the gap
+     between the two centres is 0.10–0.13 of the title's size, drifting a
+     little because Chromium rounds font ascent and descent to whole pixels
+     when it places the baseline. Transform, so the row's height is unchanged. */
+  translate: 0 calc(var(--title-size, var(--step-2)) * -0.115);
   transition:
     color var(--transition),
     background-color var(--transition);
@@ -1004,6 +1015,34 @@ a.taste-name {
   margin-inline: 0.15rem;
 }
 
+.now-updated {
+  margin: 0 0 var(--space-block);
+  color: var(--color-muted);
+  font-size: var(--step--1);
+}
+
+.now-about {
+  margin-block-start: var(--space-section);
+  padding-block-start: 1rem;
+  border-top: 1px solid var(--color-border);
+  color: var(--color-muted);
+  font-size: var(--step--1);
+  text-wrap: pretty;
+}
+
+.now-about a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--color-underline);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.19em;
+  transition: color var(--transition);
+}
+
+.now-about a:hover {
+  color: var(--color-accent);
+}
+
 .places-stats {
   margin: 0 0 1.25rem;
   color: var(--color-muted);
@@ -1495,10 +1534,7 @@ pre.mermaid svg {
      masthead should instead of competing with the links for width. */
   .header-brand {
     flex-basis: 100%;
-  }
-
-  .site-title {
-    font-size: var(--step-3);
+    --title-size: var(--step-3);
   }
 
   .theme-toggle {

--- a/content/_index.md
+++ b/content/_index.md
@@ -28,6 +28,6 @@ intersection of ML and safety-critical systems.
 
 ## Beyond Code
 
-I really enjoy learning something new - practicing Jiu Jitsu techniques,
-exploring the chess openings, or traveling to new places. I speak English,
+I really enjoy learning something new - playing football (soccer), exploring
+chess, or traveling to new places. I speak English,
 Russian, and German and share my home with three crazy Abyssinian cats.

--- a/content/blog/features-demo.md
+++ b/content/blog/features-demo.md
@@ -172,7 +172,7 @@ figures a static image or Mermaid diagram can't express:
 
 {{< embed src="/embeds/demo-bars.html" height="220" caption="A minimal interactive demo, embedded via the `embed` shortcode." />}}
 
-The embedded file can pull in a charting library too &mdash; here D3 is loaded
+The embedded file can pull in a charting library too - here D3 is loaded
 from a pinned CDN version inside the standalone HTML file itself, same as any
 other embed:
 

--- a/content/now.md
+++ b/content/now.md
@@ -1,0 +1,35 @@
++++
+title = 'Now'
+description = 'What has my attention at the moment.'
+layout = 'now'
+draft = true
++++
+
+## Work
+
+Machine learning models for autonomous vehicle simulation at Waymo — making
+simulations more realistic, robust, and performant.
+
+_[One or two sentences on what specifically has your attention this quarter.
+This is the part people actually read.]_
+
+## Writing
+
+_[Anything in progress. The chess post ends by promising "a consequent study
+which I want to publish soon" — if that is still alive, say so here.]_
+
+## Learning
+
+_[A language, a course, a paper, a technique. You already write about Anki, so
+what you are putting into it is a natural fit.]_
+
+## Away from the keyboard
+
+Jiu Jitsu, chess openings, and three Abyssinian cats.
+
+_[Anything you would want a friend to ask you about over coffee.]_
+
+## Where
+
+_[Which city, and whether you are travelling anywhere soon — this is the line
+that pairs with the places page.]_

--- a/content/now.md
+++ b/content/now.md
@@ -7,7 +7,7 @@ draft = true
 
 ## Work
 
-Machine learning models for autonomous vehicle simulation at Waymo — making
+Machine learning models for autonomous vehicle simulation at Waymo - making
 simulations more realistic, robust, and performant.
 
 _[One or two sentences on what specifically has your attention this quarter.
@@ -16,7 +16,7 @@ This is the part people actually read.]_
 ## Writing
 
 _[Anything in progress. The chess post ends by promising "a consequent study
-which I want to publish soon" — if that is still alive, say so here.]_
+which I want to publish soon" - if that is still alive, say so here.]_
 
 ## Learning
 
@@ -25,11 +25,11 @@ what you are putting into it is a natural fit.]_
 
 ## Away from the keyboard
 
-Jiu Jitsu, chess openings, and three Abyssinian cats.
+Football (soccer), chess, and three Abyssinian cats.
 
 _[Anything you would want a friend to ask you about over coffee.]_
 
 ## Where
 
-_[Which city, and whether you are travelling anywhere soon — this is the line
+_[Which city, and whether you are travelling anywhere soon - this is the line
 that pairs with the places page.]_

--- a/data/places.toml
+++ b/data/places.toml
@@ -3,7 +3,7 @@
 # render from this file. `country` should be the common English name
 # (Natural Earth naming; assets/js/places.js has an alias map for the
 # few that differ, e.g. United States). `when` is free-form and
-# optional ('2023', '2019—', 'every summer').
+# optional ('2023', '2019-', 'every summer').
 
 [[places]]
   city = 'Miami'

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -12,6 +12,10 @@
     </div>
   </div>
   <nav class="footer-nav" aria-label="Footer">
+    {{- /* Resolved rather than hardcoded, so the link appears only once the page is real (see me-nav.html). */ -}}
+    {{- with site.GetPage "/now" -}}
+      <a href="{{ .RelPermalink }}">Now</a>
+    {{- end -}}
     <a href="/taste/">Taste</a>
     <a href="/places/">Places</a>
     <a href="/index.xml">RSS</a>

--- a/layouts/_partials/me-nav.html
+++ b/layouts/_partials/me-nav.html
@@ -1,4 +1,4 @@
-{{- /* Shared nav across the personal pages. Entries resolve through site.GetPage, so one that does not exist yet — or is still a draft — drops out rather than shipping a dead link. */ -}}
+{{- /* Shared nav across the personal pages. Entries resolve through site.GetPage, so one that does not exist yet - or is still a draft - drops out rather than shipping a dead link. */ -}}
 {{- $wanted := slice
   (dict "path" "/now" "label" "now")
   (dict "path" "/taste" "label" "taste")

--- a/layouts/_partials/me-nav.html
+++ b/layouts/_partials/me-nav.html
@@ -1,0 +1,25 @@
+{{- /* Shared nav across the personal pages. Entries resolve through site.GetPage, so one that does not exist yet — or is still a draft — drops out rather than shipping a dead link. */ -}}
+{{- $wanted := slice
+  (dict "path" "/now" "label" "now")
+  (dict "path" "/taste" "label" "taste")
+  (dict "path" "/places" "label" "places")
+-}}
+{{- $items := slice -}}
+{{- range $wanted -}}
+  {{- $label := .label -}}
+  {{- with site.GetPage .path -}}
+    {{- $items = $items | append (dict "url" .RelPermalink "label" $label) -}}
+  {{- end -}}
+{{- end -}}
+{{- with $items -}}
+  <nav class="me-nav" aria-label="Personal pages">
+    {{- range $i, $item := . -}}
+      {{- if $i }}<span class="me-nav-sep">&middot;</span>{{ end -}}
+      {{- if eq $.RelPermalink $item.url -}}
+        <span aria-current="page">{{ $item.label }}</span>
+      {{- else -}}
+        <a href="{{ $item.url }}">{{ $item.label }}</a>
+      {{- end -}}
+    {{- end -}}
+  </nav>
+{{- end -}}

--- a/layouts/_partials/og-image.html
+++ b/layouts/_partials/og-image.html
@@ -1,7 +1,7 @@
 {{- /* Returns a generated 1200x630 Open Graph card for a blog post (or "" for anything else). */ -}}
 {{- /* Composed at build time: the light-theme base canvas (assets/images/og-base.png) plus the */ -}}
 {{- /* post title set in Newsreader and a site/date line in Inter. The TTFs in assets/fonts/ */ -}}
-{{- /* exist only for this partial — images.Text cannot read the woff2 files the site serves. */ -}}
+{{- /* exist only for this partial - images.Text cannot read the woff2 files the site serves. */ -}}
 {{- $img := "" -}}
 {{- if and .IsPage (eq .Section "blog") -}}
   {{- /* Greedy-wrap the title: images.Text only breaks lines at the image edge, which would */ -}}

--- a/layouts/_shortcodes/embed.html
+++ b/layouts/_shortcodes/embed.html
@@ -1,6 +1,6 @@
 {{- /*
   Embed shortcode: drops a sandboxed iframe pointing at a self-contained
-  static HTML file (own inline JS/CSS, no dependency on the site's build —
+  static HTML file (own inline JS/CSS, no dependency on the site's build -
   e.g. a D3 chart or an exported Observable notebook) for interactive
   figures that a plain image/Mermaid diagram can't express.
   API: src (required, path to the embed's HTML file, e.g. /embeds/foo.html),
@@ -11,7 +11,7 @@
   the toggle too, an embed's own script should listen for a postMessage from
   the parent and set data-theme on its own <html>. The iframe has no
   allow-same-origin (deliberately, to avoid sandbox-escape via allow-scripts
-  + allow-same-origin together), which makes it an opaque origin — targeting
+  + allow-same-origin together), which makes it an opaque origin - targeting
   it with location.origin instead of "*" would silently fail to deliver, and
   e.source === window.parent is unreliable for the same reason, so validate
   the message's value instead of its sender (harmless payload, so that's a

--- a/layouts/baseof.html
+++ b/layouts/baseof.html
@@ -21,7 +21,7 @@
         const current = () =>
           document.documentElement.dataset.theme || system();
         // Embeds (see the `embed` shortcode) run in a sandboxed iframe with
-        // no allow-same-origin, so they have an opaque origin — they can't
+        // no allow-same-origin, so they have an opaque origin - they can't
         // see data-theme on our <html> or read our localStorage, and a
         // postMessage targetOrigin of location.origin would never match
         // (it'd never be delivered), hence "*" here. Embeds that want to

--- a/layouts/now.html
+++ b/layouts/now.html
@@ -1,0 +1,24 @@
+{{- define "main" -}}
+  <article class="main-content">
+    <h1>{{ .Title }}</h1>
+    <p class="lede">{{ .Description }}</p>
+    {{- partial "me-nav.html" . -}}
+    {{- /* The date is the whole point of a now page: it tells a reader how much to trust what follows. Driven by git (enableGitInfo), so editing the page dates it and forgetting to edit it cannot. Guarded because an uncommitted file has no git date, and would otherwise print the zero time. */ -}}
+    {{- if not .Lastmod.IsZero -}}
+      <p class="now-updated">
+        Last updated
+        <time datetime="{{ .Lastmod.Format "2006-01-02" }}"
+          >{{ .Lastmod.Format "January 2, 2006" }}</time
+        >
+      </p>
+    {{- end -}}
+    <div class="prose">{{ .Content }}</div>
+    <p class="now-about">
+      This is a
+      <a href="https://nownownow.com/about" rel="noopener noreferrer"
+        >now page</a
+      >: what has my attention at this point in my life, rather than a record of
+      what I have done.
+    </p>
+  </article>
+{{- end -}}

--- a/layouts/places.html
+++ b/layouts/places.html
@@ -2,11 +2,7 @@
   <article class="main-content">
     <h1>{{ .Title }}</h1>
     <p class="lede">{{ .Description }}</p>
-    <nav class="me-nav" aria-label="Personal pages">
-      <a href="/taste/">taste</a>
-      <span class="me-nav-sep">&middot;</span>
-      <span aria-current="page">places</span>
-    </nav>
+    {{- partial "me-nav.html" . -}}
     {{- $places := hugo.Data.places.places -}}
     {{- $countries := slice -}}
     {{- range $places -}}

--- a/layouts/taste.html
+++ b/layouts/taste.html
@@ -55,7 +55,7 @@
               <span class="taste-name">{{ .name }}</span>
             {{- end }}
             {{- with .note }}
-              <span class="taste-sep">&mdash;</span>
+              <span class="taste-sep">-</span>
               <span class="taste-note">{{ . }}</span>
             {{- end }}
           </li>

--- a/layouts/taste.html
+++ b/layouts/taste.html
@@ -2,11 +2,7 @@
   <article class="main-content">
     <h1>{{ .Title }}</h1>
     <p class="lede">{{ .Description }}</p>
-    <nav class="me-nav" aria-label="Personal pages">
-      <span aria-current="page">taste</span>
-      <span class="me-nav-sep">&middot;</span>
-      <a href="/places/">places</a>
-    </nav>
+    {{- partial "me-nav.html" . -}}
     {{- $taste := hugo.Data.taste -}}
 
 

--- a/static/embeds/demo-bars.html
+++ b/static/embeds/demo-bars.html
@@ -64,7 +64,7 @@
 </head>
 <body>
 <main>
-  <p class="hint">Hover or focus a bar &mdash; this is a plain static HTML file, embedded via the <code>embed</code> shortcode.</p>
+  <p class="hint">Hover or focus a bar - this is a plain static HTML file, embedded via the <code>embed</code> shortcode.</p>
   <div class="bars" id="bars"></div>
   <output id="readout">&nbsp;</output>
 </main>

--- a/static/embeds/demo-d3-scatter.html
+++ b/static/embeds/demo-d3-scatter.html
@@ -72,7 +72,7 @@
 </head>
 <body>
 <main>
-  <p class="hint">A D3 scatter plot, embedded via the <code>embed</code> shortcode &mdash; D3 loaded from a pinned CDN version inside this standalone HTML file.</p>
+  <p class="hint">A D3 scatter plot, embedded via the <code>embed</code> shortcode - D3 loaded from a pinned CDN version inside this standalone HTML file.</p>
   <svg id="chart"></svg>
 </main>
 <script>


### PR DESCRIPTION
Two unrelated things, both small.

## Theme toggle alignment

The toggle sat where `align-items: center` put it — on the centre of the title's **line box**. A Title Case name reads as its **cap band** (baseline up to cap top), which sits higher, so a symmetrically drawn icon looked low beside it.

I measured this against rendered pixels rather than font metrics, because Chromium rounds font ascent and descent to whole pixels when it places the baseline, so the offset does not reduce to one clean ratio:

| | title size | icon offset from cap-band centre |
|---|---|---|
| before, 390 px | 29.38 px | **3.75 px low** |
| before, 1440 px | 24.48 px | **2.44 px low** |
| after, 390 px | 29.38 px | 0.37 px |
| after, 1440 px | 24.48 px | −0.38 px |

The fix lifts the icon by `0.115` of the title's size, which lands within 0.4 px of the cap-band centre at both breakpoints. The size moved into a `--title-size` custom property set on `.header-brand`, so the title and the lift can't drift apart when a breakpoint changes the type scale. It's a `translate`, so the row's height is unchanged.

## /now page

Scaffolding for a [now page](https://nownownow.com/about), in the Derek Sivers sense: what has my attention at this point in life, not a record of what I've done.

**It ships as a draft.** The prose is placeholders wherever I'd be inventing facts — the only content that isn't a placeholder is what the site already says elsewhere (Waymo, Jiu Jitsu, chess, the cats). Preview it with `hugo server -D`, rewrite it, then drop `draft = true`.

Details worth flagging:

- **The date comes from git**, not front matter. `enableGitInfo` was already on and unused here, so editing the page dates it and forgetting to edit it can't. Guarded on `.Lastmod.IsZero`, because an uncommitted file has no git date and would otherwise print `January 1, 0001` — which it did, on the first build.
- **The personal-pages nav became a partial.** `taste.html` and `places.html` each hand-rolled the same markup, and adding a third page meant editing both. Entries now resolve through `site.GetPage`, so `/now` drops out of the nav *and* the footer while it's a draft rather than shipping a dead link, and reappears in all three places the moment the flag comes off.

## Testing

- Optical alignment measured before and after by rasterising a capital `H` in the title's font at 8× and scanning for its ink top, with the baseline taken from a zero-height inline-block strut — both exact, neither relying on the integer-rounded canvas metrics that gave inconsistent answers on the first attempt.
- Production build (`hugo --gc --minify`) contains no `/now/` directory and zero links to `/now/`; the drafts build renders the page and prints `Last updated July 31, 2026` from the commit.
- `/now` rendered at 390 px and 1000 px, light and dark.
- `prettier --check` clean on templates and CSS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8LZabuU6uyhbrXEKp92TQ)_