### PR TITLE
Make nav-to-toggle spacing match the nav-item gaps

### DIFF
--- a/themes/constructivist/assets/css/main.css
+++ b/themes/constructivist/assets/css/main.css
@@ -408,6 +408,7 @@ video {
   display: flex;
   align-items: center;
   min-width: 0;
+  gap: var(--space-l);
 }
 
 .nav-list {
@@ -452,7 +453,10 @@ video {
   align-items: center;
   justify-content: center;
   border: 0;
-  margin-inline-start: var(--space-xs);
+  /* .site-nav's gap already spaces this from .nav-list like any two nav
+     items; cancel the button's own padding so that hit-area padding
+     doesn't add on top and widen this particular gap. */
+  margin-inline-start: calc(-1 * var(--space-2xs));
   padding: var(--space-2xs);
   background: none;
   color: var(--color-muted);
@@ -1203,6 +1207,10 @@ pre.mermaid svg foreignObject {
 
   .site-header[data-condensed] .header-row {
     padding-block: var(--space-xs);
+  }
+
+  .site-nav {
+    gap: var(--space-m);
   }
 
   .nav-list {


### PR DESCRIPTION
## Summary
The dark/light theme toggle sat outside `.nav-list` and got its spacing from its own `margin-inline-start` (0.5rem) plus its hit-area padding, instead of the 1.5rem `gap` used between the nav items (Blog / Now / Resume). Net visual gap before the toggle was ~14px vs. 24px between nav items.

## Fix
Moved the gap onto `.site-nav` (the flex row holding `.nav-list` and the toggle button) so it matches `.nav-list`'s own gap, and offset the toggle's hit-area padding with a matching negative margin so it doesn't stack an extra ~6px on top. Mirrored the same treatment in the mobile breakpoint.

## Verification
- `hugo --gc --minify` — clean, no warnings
- `npm run format` — no changes needed
- Measured rendered gaps in a live `hugo server` via Playwright: Blog→Now, Now→Resume, and Resume→toggle are all exactly 24px now (previously ~14px for the last gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)