### PR TITLE
Un-stick the mobile header instead of shrinking it to initials

### DIFF
--- a/themes/constructivist/assets/css/main.css
+++ b/themes/constructivist/assets/css/main.css
@@ -1199,6 +1199,20 @@ pre.mermaid svg foreignObject {
 
 /* === Responsive === */
 @media (max-width: 640px) {
+  /* No pinned masthead on mobile: at this width the title and nav already
+     wrap to two lines at rest (see .header-row's flex-wrap), so a sticky
+     header would either stay two lines tall for the whole scroll or need
+     the name-to-initials shrink to claw back one line. Simpler to just let
+     the header scroll away with the page, like the rest of the content -
+     same "no pinned masthead" call the desktop-era comments already
+     describe. The condense/shrink rules below still exist (the scroll
+     listener in baseof.html keeps toggling data-condensed regardless of
+     width), so they're neutralized here rather than left to fire on an
+     unsticky header. */
+  .site-header {
+    position: static;
+  }
+
   .header-row {
     padding-inline: var(--space-m);
     padding-block: var(--space-m);
@@ -1206,7 +1220,17 @@ pre.mermaid svg foreignObject {
   }
 
   .site-header[data-condensed] .header-row {
-    padding-block: var(--space-xs);
+    padding-block: var(--space-m);
+  }
+
+  .site-header[data-condensed] .site-title-full {
+    max-width: 16em;
+    opacity: 1;
+  }
+
+  .site-header[data-condensed] .site-title-short {
+    max-width: 0;
+    opacity: 0;
   }
 
   .site-nav {


### PR DESCRIPTION
## Summary
On mobile, the sticky header currently condenses on scroll and animates the title from "Kirill Bobyrev" to "KB" so everything fits on one pinned line. At mobile widths the title + nav already wrap to two lines at rest, so this trick was solving a problem worth avoiding instead: the header now un-sticks on mobile and scrolls away with the page like normal content — full name always shown, no condense/shrink animation.

Desktop is untouched: the sticky header, padding condense, and name → initials shrink all still work as before (there's enough width for one line there).

## Verified
- `hugo --gc --minify -D` builds clean
- Screenshotted home + blog index at 390px and 320px via a local `hugo server` + Playwright, before/after, at rest and mid-scroll — header now scrolls off normally, back-to-top button still appears on schedule, no KB flash
- Desktop (1280px) screenshotted mid-scroll — sticky/condense/KB behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)